### PR TITLE
sshd further hardening

### DIFF
--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -11,7 +11,14 @@ None
 Role Variables
 --------------
 
-None
+- `sshd_disable_pam`: whether to disable PAM support. Default: `false`
+- `sshd_password_auth`: whether to allow password authentication. Default: `false`
+- `sshd_challenge_response_auth`: whether to allow challenge-response authentication. Default: `false`
+- `sshd_gss_api_auth`: whether to allow GSSAPI authentication. Default: `false`
+- `sshd_allow_agent_forwarding`: whether to allow SSH agent forwarding. Default: `false`
+- `sshd_allow_tcp_forwarding`: whether to allow TCP forwarding. Default: `false`
+- `sshd_gateway_ports`: whether to allow gateway ports. Default: `false`
+- `sshd_permit_tunnel`: whether to allow SSH tunneling. Default: `false`
 
 Dependencies
 ------------

--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -1,34 +1,75 @@
 sshd
 ====
 
-Deploy a hardened `sshd` server
+A hardened OpenSSH server role for Debian/Ubuntu and RHEL/Rocky systems.
+
+This role installs and configures the `sshd` server with secure defaults and a small set of tunable options for authentication and forwarding.
 
 Requirements
 ------------
 
-None
+- Target hosts must be Debian-family or RedHat-family Linux systems
+
+Supported Platforms
+-------------------
+
+- Debian
+- Ubuntu
+- RHEL 9+
+- Rocky Linux 9+
 
 Role Variables
 --------------
 
-- `sshd_disable_pam`: whether to disable PAM support. Default: `false`
-- `sshd_password_auth`: whether to allow password authentication. Default: `false`
-- `sshd_challenge_response_auth`: whether to allow challenge-response authentication. Default: `false`
-- `sshd_gss_api_auth`: whether to allow GSSAPI authentication. Default: `false`
-- `sshd_allow_agent_forwarding`: whether to allow SSH agent forwarding. Default: `false`
-- `sshd_allow_tcp_forwarding`: whether to allow TCP forwarding. Default: `false`
-- `sshd_gateway_ports`: whether to allow gateway ports. Default: `false`
-- `sshd_permit_tunnel`: whether to allow SSH tunneling. Default: `false`
+Authentication
 
-Dependencies
-------------
+- `sshd_disable_pam`: disable PAM support in `sshd_config`. Default: `false`
+- `sshd_password_auth`: allow password authentication. Default: `false`
+- `sshd_challenge_response_auth`: allow challenge-response authentication. Default: `false`
+- `sshd_gss_api_auth`: allow GSSAPI authentication. Default: `false`
 
-None
+Forwarding & tunneling
+
+- `sshd_allow_agent_forwarding`: allow SSH agent forwarding. Default: `false`
+- `sshd_allow_tcp_forwarding`: allow TCP forwarding. Default: `false`
+- `sshd_gateway_ports`: allow gateway ports. Default: `false`
+- `sshd_permit_tunnel`: allow SSH tunneling. Default: `false`
+
+Access control
+
+- `sshd_allow_users`: optional space-separated list of users permitted to log in via SSH
+- `sshd_allow_groups`: optional space-separated list of groups permitted to log in via SSH
+
+Behavior
+--------
+
+By default this role:
+
+- installs `openssh-server`
+- enforces `Protocol 2`
+- disables `PermitRootLogin`
+- disables `X11Forwarding`, `HostbasedAuthentication`, `KbdInteractiveAuthentication`, and `PermitUserEnvironment`
+- disables weak(-er) host keys (`ecdsa`, `dsa`)
+- disables empty passwords
+- sets `LogLevel VERBOSE`
+- restricts `/etc/ssh/sshd_config` to `0600`
+
+Compatibility Notes
+-------------------
+
+- The role uses `sshd` validation via `/usr/sbin/sshd -t -f %s`.
+- Debian/Ubuntu systems use the `ssh` service name; RHEL/Rocky systems use `sshd`.
+- The role is intentionally conservative with forwarding and tunneling defaults.
 
 Example Playbook
 ----------------
 
 See: [converge.yml](molecule/default/converge.yml)
+
+Dependencies
+------------
+
+None
 
 License
 -------

--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -3,3 +3,7 @@ sshd_disable_pam: false
 sshd_password_auth: false
 sshd_challenge_response_auth: false
 sshd_gss_api_auth: false
+sshd_allow_agent_forwarding: false
+sshd_allow_tcp_forwarding: false
+sshd_gateway_ports: false
+sshd_permit_tunnel: false

--- a/roles/sshd/handlers/main.yml
+++ b/roles/sshd/handlers/main.yml
@@ -1,7 +1,18 @@
 ---
-- name: "Restart sshd"
+- name: "Restart the ssh service"
+  listen: "Restart ssh"
+  when: ansible_os_family == 'Debian'
   ansible.builtin.service:
     name: ssh
+    state: restarted
+    enabled: true
+    daemon_reload: true
+
+- name: "Restart the sshd service"
+  listen: "Restart ssh"
+  when: ansible_os_family == 'RedHat'
+  ansible.builtin.service:
+    name: sshd
     state: restarted
     enabled: true
     daemon_reload: true

--- a/roles/sshd/molecule/default/converge.yml
+++ b/roles/sshd/molecule/default/converge.yml
@@ -3,4 +3,9 @@
   hosts: all
   roles:
     - role: "genlab.common.sshd"
+      sshd_password_auth: false
+      sshd_allow_agent_forwarding: false
+      sshd_allow_tcp_forwarding: false
+      sshd_gateway_ports: false
+      sshd_permit_tunnel: false
       sshd_allow_users: "testusr"

--- a/roles/sshd/tasks/algorithms.yml
+++ b/roles/sshd/tasks/algorithms.yml
@@ -1,6 +1,6 @@
 ---
 # next task requires this directory to exist for sshd -t flag
-- name: Ensure /run/sshd exists
+- name: "Algorithms | Ensure /run/sshd exists"
   ansible.builtin.file:
     path: /run/sshd
     state: directory

--- a/roles/sshd/tasks/algorithms.yml
+++ b/roles/sshd/tasks/algorithms.yml
@@ -15,7 +15,7 @@
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_ed25519_key'
     line: 'HostKey /etc/ssh/ssh_host_ed25519_key'
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s
 
 - name: "Algorithms | enable the RSA authentication algorithm"
   notify: "Restart ssh"
@@ -23,7 +23,7 @@
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_rsa_key'
     line: 'HostKey /etc/ssh/ssh_host_rsa_key'
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s
 
 - name: "Algorithms | disable the ECDSA algorithm (deemed to be less safe)"
   notify: "Restart ssh"
@@ -31,7 +31,7 @@
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_ecdsa_key'
     state: absent
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s
 
 - name: "Algorithms | disable the DSA algorithm (considered to be defunct)"
   notify: "Restart ssh"
@@ -39,4 +39,4 @@
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_dsa_key'
     state: absent
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s

--- a/roles/sshd/tasks/algorithms.yml
+++ b/roles/sshd/tasks/algorithms.yml
@@ -10,7 +10,7 @@
 
 # NOTE: order of preference for openssh-server ed25519 -> rsa
 - name: "Algorithms | enable ed25519 authentication algorithm"
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_ed25519_key'
@@ -18,7 +18,7 @@
     validate: sshd -f %s -t
 
 - name: "Algorithms | enable the RSA authentication algorithm"
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_rsa_key'
@@ -26,7 +26,7 @@
     validate: sshd -f %s -t
 
 - name: "Algorithms | disable the ECDSA algorithm (deemed to be less safe)"
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_ecdsa_key'
@@ -34,7 +34,7 @@
     validate: sshd -f %s -t
 
 - name: "Algorithms | disable the DSA algorithm (considered to be defunct)"
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^HostKey /etc/ssh/ssh_host_dsa_key'

--- a/roles/sshd/tasks/algorithms.yml
+++ b/roles/sshd/tasks/algorithms.yml
@@ -1,6 +1,6 @@
 ---
 # next task requires this directory to exist for sshd -t flag
-- name: "Algorithms | Ensure /run/sshd exists"
+- name: "Algorithms | ensure /run/sshd exists"
   ansible.builtin.file:
     path: /run/sshd
     state: directory

--- a/roles/sshd/tasks/authentication.yml
+++ b/roles/sshd/tasks/authentication.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Authentication | Configure SSH authentication settings"
+- name: "Authentication | configure SSH authentication settings"
   notify: "Restart ssh"
   loop:
     - { regexp: '^#?\s*PubkeyAuthentication\s+', line: 'PubkeyAuthentication yes' }
@@ -17,7 +17,7 @@
     line: "{{ item.line }}"
     validate: /usr/sbin/sshd -t -f %s
 
-- name: "Check if there is an SSH config forced by cloud-init"
+- name: "Authentication | check if there is an SSH config forced by cloud-init"
   register: sshd_cloud_init
   ansible.builtin.stat:
     path: "/etc/ssh/sshd_config.d/50-cloud-init.conf"

--- a/roles/sshd/tasks/authentication.yml
+++ b/roles/sshd/tasks/authentication.yml
@@ -7,6 +7,9 @@
     - { regexp: '^#?\s*PermitEmptyPasswords\s+', line: 'PermitEmptyPasswords no' }
     - { regexp: '^#?\s*ChallengeResponseAuthentication\s+', line: 'ChallengeResponseAuthentication {{ sshd_challenge_response_auth | ternary("yes", "no") }}' }
     - { regexp: '^#?\s*GSSAPIAuthentication\s+', line: 'GSSAPIAuthentication {{ sshd_gss_api_auth | ternary("yes", "no") }}' }
+    - { regexp: '^#?IgnoreRhosts', line: 'IgnoreRhosts yes' }
+    - { regexp: '^#?\s*KbdInteractiveAuthentication\s+', line: 'KbdInteractiveAuthentication no' }
+    - { regexp: '^#?\s*HostbasedAuthentication\s+', line: 'HostbasedAuthentication no' }
     - {
       regexp: '^#?\s*AuthenticationMethods\s+',
       line: "{{ 'AuthenticationMethods publickey password' if sshd_password_auth else 'AuthenticationMethods publickey' }}"

--- a/roles/sshd/tasks/authentication.yml
+++ b/roles/sshd/tasks/authentication.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Authentication | Configure SSH authentication settings"
-  notify: Restart sshd
+  notify: "Restart ssh"
   loop:
     - { regexp: '^#?\s*PubkeyAuthentication\s+', line: 'PubkeyAuthentication yes' }
     - { regexp: '^#?\s*PasswordAuthentication\s+', line: 'PasswordAuthentication {{ sshd_password_auth | ternary("yes", "no") }}' }
@@ -24,7 +24,7 @@
 
 - name: "Authentication | override password authentication by cloud-init to '{{ sshd_password_auth | ternary('yes', 'no') }}'"
   when: sshd_cloud_init.stat.exists
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: "/etc/ssh/sshd_config.d/50-cloud-init.conf"
     regexp: '^#?PasswordAuthentication'

--- a/roles/sshd/tasks/encryption.yml
+++ b/roles/sshd/tasks/encryption.yml
@@ -5,7 +5,7 @@
     - /etc/ssh/ssh_host_ecdsa_key.pub
     - /etc/ssh/ssh_host_dsa_key
     - /etc/ssh/ssh_host_dsa_key.pub
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent

--- a/roles/sshd/tasks/install.yml
+++ b/roles/sshd/tasks/install.yml
@@ -1,11 +1,11 @@
 ---
-- name: "Install | install OpenSSH (RHEL flavours)"
+- name: "Install | install OpenSSH server (RHEL flavours)"
   when: ansible_os_family == "RHEL"
   ansible.builtin.dnf:
-    name: openssh
+    name: openssh-server
     state: installed
 
-- name: "Install | Install OpenSSH (Debian flavours)"
+- name: "Install | Install OpenSSH server (Debian flavours)"
   when: ansible_os_family == "Debian"
   ansible.builtin.apt:
     name: openssh-server

--- a/roles/sshd/tasks/install.yml
+++ b/roles/sshd/tasks/install.yml
@@ -5,7 +5,7 @@
     name: openssh-server
     state: installed
 
-- name: "Install | Install OpenSSH server (Debian flavours)"
+- name: "Install | install OpenSSH server (Debian flavours)"
   when: ansible_os_family == "Debian"
   ansible.builtin.apt:
     name: openssh-server

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -18,7 +18,7 @@
   ansible.builtin.include_tasks: "whitelists.yml"
 
 - name: "Log at VERBOSE level"
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^#?LogLevel'

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -23,4 +23,4 @@
     path: /etc/ssh/sshd_config
     regexp: '^#?LogLevel'
     line: 'LogLevel VERBOSE'
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -10,6 +10,10 @@
     - { regexp: '^#?\s*KbdInteractiveAuthentication\s+', line: 'KbdInteractiveAuthentication no' }
     - { regexp: '^#?\s*HostbasedAuthentication\s+', line: 'HostbasedAuthentication no' }
     - { regexp: '^#?\s*PermitUserEnvironment\s+', line: 'PermitUserEnvironment no' }
+    - { regexp: '^#?\s*AllowAgentForwarding\s+', line: 'AllowAgentForwarding {{ sshd_allow_agent_forwarding | ternary("yes", "no") }}' }
+    - { regexp: '^#?\s*AllowTcpForwarding\s+', line: 'AllowTcpForwarding {{ sshd_allow_tcp_forwarding | ternary("yes", "no") }}' }
+    - { regexp: '^#?\s*GatewayPorts\s+', line: 'GatewayPorts {{ sshd_gateway_ports | ternary("yes", "no") }}' }
+    - { regexp: '^#?\s*PermitTunnel\s+', line: 'PermitTunnel {{ sshd_permit_tunnel | ternary("yes", "no") }}' }
     - { regexp: '^#?\s*StrictModes\s+', line: 'StrictModes yes' }
     - { regexp: '^#?\s*IgnoreUserKnownHosts\s+', line: 'IgnoreUserKnownHosts yes' }
   ansible.builtin.lineinfile:

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -4,9 +4,6 @@
     - { regexp: '^#?Protocol\s+', line: 'Protocol 2' }
     - { regexp: '^#?\s*PermitRootLogin\s+', line: 'PermitRootLogin no' }
     - { regexp: '^#?X11Forwarding', line: 'X11Forwarding no' }
-    - { regexp: '^#?IgnoreRhosts', line: 'IgnoreRhosts yes' }
-    - { regexp: '^#?\s*KbdInteractiveAuthentication\s+', line: 'KbdInteractiveAuthentication no' }
-    - { regexp: '^#?\s*HostbasedAuthentication\s+', line: 'HostbasedAuthentication no' }
     - { regexp: '^#?\s*PermitUserEnvironment\s+', line: 'PermitUserEnvironment no' }
     - { regexp: '^#?\s*AllowAgentForwarding\s+', line: 'AllowAgentForwarding {{ sshd_allow_agent_forwarding | ternary("yes", "no") }}' }
     - { regexp: '^#?\s*AllowTcpForwarding\s+', line: 'AllowTcpForwarding {{ sshd_allow_tcp_forwarding | ternary("yes", "no") }}' }

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -36,7 +36,7 @@
     path: /etc/ssh/sshd_config
     regexp: '^#?UsePAM'
     line: "UsePAM {{ sshd_disable_pam | ternary('no', 'yes') }}"
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s
 
 - name: "Restrictions | ensure the SSHD config is restricted to the root user"
   notify: "Restart ssh"

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -31,7 +31,7 @@
     validate: /usr/sbin/sshd -t -f %s
 
 - name: "Restrictions | toggle PAM"
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^#?UsePAM'
@@ -39,7 +39,7 @@
     validate: sshd -f %s -t
 
 - name: "Restrictions | ensure the SSHD config is restricted to the root user"
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.file:
     path: /etc/ssh/sshd_config
     owner: root

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -5,8 +5,6 @@
     - { regexp: '^#?\s*PermitRootLogin\s+', line: 'PermitRootLogin no' }
     - { regexp: '^#?X11Forwarding', line: 'X11Forwarding no' }
     - { regexp: '^#?IgnoreRhosts', line: 'IgnoreRhosts yes' }
-    - { regexp: '^#?DebianBanner\s+', line: 'DebianBanner no' }
-  notify: Restart sshd
     - { regexp: '^#?\s*KbdInteractiveAuthentication\s+', line: 'KbdInteractiveAuthentication no' }
     - { regexp: '^#?\s*HostbasedAuthentication\s+', line: 'HostbasedAuthentication no' }
     - { regexp: '^#?\s*PermitUserEnvironment\s+', line: 'PermitUserEnvironment no' }
@@ -16,10 +14,20 @@
     - { regexp: '^#?\s*PermitTunnel\s+', line: 'PermitTunnel {{ sshd_permit_tunnel | ternary("yes", "no") }}' }
     - { regexp: '^#?\s*StrictModes\s+', line: 'StrictModes yes' }
     - { regexp: '^#?\s*IgnoreUserKnownHosts\s+', line: 'IgnoreUserKnownHosts yes' }
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
+    validate: /usr/sbin/sshd -t -f %s
+
+- name: "Restrictions | disable Debian banner"
+  when: "ansible_os_family == 'Debian'"
+  notify: "Restart ssh"
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?DebianBanner\s+'
+    line: "DebianBanner no"
     validate: /usr/sbin/sshd -t -f %s
 
 - name: "Restrictions | toggle PAM"

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Restrictions | Configure SSH security restrictions"
+- name: "Restrictions | configure SSH security restrictions"
   loop:
     - { regexp: '^#?Protocol\s+', line: 'Protocol 2' }
     - { regexp: '^#?\s*PermitRootLogin\s+', line: 'PermitRootLogin no' }

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -2,7 +2,7 @@
 - name: "Restrictions | Configure SSH security restrictions"
   loop:
     - { regexp: '^#?Protocol\s+', line: 'Protocol 2' }
-    - { regexp: '^PermitRootLogin yes', line: 'PermitRootLogin no' }
+    - { regexp: '^#?\s*PermitRootLogin\s+', line: 'PermitRootLogin no' }
     - { regexp: '^#?X11Forwarding', line: 'X11Forwarding no' }
     - { regexp: '^#?IgnoreRhosts', line: 'IgnoreRhosts yes' }
     - { regexp: '^#?DebianBanner\s+', line: 'DebianBanner no' }

--- a/roles/sshd/tasks/restrictions.yml
+++ b/roles/sshd/tasks/restrictions.yml
@@ -7,6 +7,11 @@
     - { regexp: '^#?IgnoreRhosts', line: 'IgnoreRhosts yes' }
     - { regexp: '^#?DebianBanner\s+', line: 'DebianBanner no' }
   notify: Restart sshd
+    - { regexp: '^#?\s*KbdInteractiveAuthentication\s+', line: 'KbdInteractiveAuthentication no' }
+    - { regexp: '^#?\s*HostbasedAuthentication\s+', line: 'HostbasedAuthentication no' }
+    - { regexp: '^#?\s*PermitUserEnvironment\s+', line: 'PermitUserEnvironment no' }
+    - { regexp: '^#?\s*StrictModes\s+', line: 'StrictModes yes' }
+    - { regexp: '^#?\s*IgnoreUserKnownHosts\s+', line: 'IgnoreUserKnownHosts yes' }
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: "{{ item.regexp }}"

--- a/roles/sshd/tasks/whitelists.yml
+++ b/roles/sshd/tasks/whitelists.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Configure AllowUsers"
+- name: "Whitelists | configure AllowUsers"
   when: sshd_allow_users is defined
   notify: "Restart ssh"
   ansible.builtin.lineinfile:
@@ -8,7 +8,7 @@
     line: "AllowUsers {{ sshd_allow_users }}"
     validate: /usr/sbin/sshd -t -f %s
 
-- name: "Configure AllowGroups"
+- name: "Whitelists | configure AllowGroups"
   when: sshd_allow_groups is defined
   notify: "Restart ssh"
   ansible.builtin.lineinfile:

--- a/roles/sshd/tasks/whitelists.yml
+++ b/roles/sshd/tasks/whitelists.yml
@@ -6,7 +6,7 @@
     path: /etc/ssh/sshd_config
     regexp: '^#?\s*AllowUsers\s+'
     line: "AllowUsers {{ sshd_allow_users }}"
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s
 
 - name: "Configure AllowGroups"
   when: sshd_allow_groups is defined
@@ -15,4 +15,4 @@
     path: /etc/ssh/sshd_config
     regexp: '^#?\s*AllowGroups\s+'
     line: "AllowGroups {{ sshd_allow_groups }}"
-    validate: sshd -f %s -t
+    validate: /usr/sbin/sshd -t -f %s

--- a/roles/sshd/tasks/whitelists.yml
+++ b/roles/sshd/tasks/whitelists.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Configure AllowUsers"
   when: sshd_allow_users is defined
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^#?\s*AllowUsers\s+'
@@ -10,7 +10,7 @@
 
 - name: "Configure AllowGroups"
   when: sshd_allow_groups is defined
-  notify: Restart sshd
+  notify: "Restart ssh"
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^#?\s*AllowGroups\s+'


### PR DESCRIPTION
- **Make `PermitRootLogin` regexp more generic**
- **Add more configuration restrictions**
- **Add controls for tunneling and forwarding**
- **Fix incorrect package being installed for RHEL 9+ derivatives**
- **Ensure `DebianBanner` is only handled on Debian derivatives**
- **Fix handlers**
- **Use full path in config validation consistently**
- **Restore task naming consistency**
